### PR TITLE
Fix file test

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,5 +13,6 @@ copyright_year   = 2014
 
 [Encoding]
 filename = t/data/example_manifest.xlsx
+filename = t/data/02_excel.xlsx
 
 encoding = bytes

--- a/lib/Bio/Metadata/Reader.pm
+++ b/lib/Bio/Metadata/Reader.pm
@@ -65,7 +65,7 @@ sub read_csv {
   die "ERROR: no such input file ('$file')" unless -e $file;
 
   my $file_type = `file $file`;
-  die 'ERROR: not a CSV file' if ( $file_type and $file_type !~ m/ASCII text/ );
+  die 'ERROR: not a CSV file' if ( $file_type and $file_type !~ m/ASCII (\S+)? text/ );
 
   # get the header row from the checklist
   my $header = substr( $self->checklist->{header_row} || '', 0, 20 );

--- a/lib/Bio/Metadata/Reader.pm
+++ b/lib/Bio/Metadata/Reader.pm
@@ -65,7 +65,7 @@ sub read_csv {
   die "ERROR: no such input file ('$file')" unless -e $file;
 
   my $file_type = `file $file`;
-  die 'ERROR: not a CSV file' if ( $file_type and $file_type !~ m/ASCII (\S+)? text/ );
+  die 'ERROR: not a CSV file' if ( $file_type and $file_type !~ m/ASCII [\w ]*text/ );
 
   # get the header row from the checklist
   my $header = substr( $self->checklist->{header_row} || '', 0, 20 );


### PR DESCRIPTION
Fix the regex that checks the output of the "file" command that we use for checking for binary uploads. Flag an excel test document as binary for dzil.