### PR TITLE
Check for data in unused columns

### DIFF
--- a/lib/Bio/Metadata/Manifest.pm
+++ b/lib/Bio/Metadata/Manifest.pm
@@ -93,8 +93,15 @@ sub _around_add_rows {
 
     # now we know that there are actual values in the fields of this row.
     # Truncate the row to the same length as the checklist header row
-    splice @$row, $self->_num_fields;
+    my @chopped_fields = splice @$row, $self->_num_fields;
 
+    # let the user know if we're throwing away data in those removed columns
+    my $joined_chopped_fields = join ', ', @chopped_fields;
+
+    warn "WARNING: found data in unused fields ($joined_chopped_fields)"
+      if join('', @chopped_fields) ne '';
+
+    # and finally, store the remaining row data
     push @output_rows, $row;
   }
 
@@ -123,9 +130,13 @@ sub _around_add_row {
       warn "WARNING: refusing to add an empty row to the manifest";
       return $self->$orig(@_);
     }
-  }
 
-  splice @$row, $self->_num_fields;
+    my @chopped_fields = splice @$row, $self->_num_fields;
+
+    my $joined_chopped_fields = join ', ', @chopped_fields;
+    warn "WARNING: found data in unused fields ($joined_chopped_fields)"
+      if join('', @chopped_fields) ne '';
+  }
 
   return $self->$orig($row);
 }

--- a/t/03_manifest.t
+++ b/t/03_manifest.t
@@ -3,8 +3,9 @@
 use strict;
 use warnings;
 
-use Test::More tests => 21;
+use Test::More tests => 22;
 use Test::Exception;
+use Test::Warn;
 use File::Temp;
 use File::Slurp qw( read_file );
 
@@ -41,7 +42,12 @@ my $expected_field_names = [ qw( one two ) ];
 is_deeply( $m->fields,      $expected_field_defs,  'got expected fields from checklist via manifest' );
 is_deeply( $m->field_names, $expected_field_names, 'got expected field names from checklist via manifest' );
 
-$m->add_rows( [ '1,1', 2, undef ], [ 3, 4, undef ], [ 5, 6, undef ], [ undef, undef, undef ] );
+warning_like {
+  $m->add_rows( [ '1,1', 2, undef ], [ 3, 4, undef ], [ 5, 6, 'value in unused field' ],
+    [ undef, undef, undef ] )
+}
+  qr/data in unused fields/, 'got warning about data in unused fields';
+
 $m->set_row_error( 2, '[error message]' );
 
 is( $m->row_count, 3, 'starting with 3 rows' );

--- a/t/data/06_broken.conf
+++ b/t/data/06_broken.conf
@@ -1,5 +1,5 @@
 <checklist broken>
-  header_row "one,two,three"
+  header_row "one,two,three,four,five,six,seven,eight,nine"
 
   <dependencies>
     # the "if" column should be a Bool but it's not and we should see an exception
@@ -20,6 +20,30 @@
   </field>
   <field>
     name  three
+    type  Str
+  </field>
+  <field>
+    name  four
+    type  Str
+  </field>
+  <field>
+    name  five
+    type  Str
+  </field>
+  <field>
+    name  six
+    type  Str
+  </field>
+  <field>
+    name  seven
+    type  Str
+  </field>
+  <field>
+    name  eight
+    type  Str
+  </field>
+  <field>
+    name  nine
     type  Str
   </field>
 </checklist>


### PR DESCRIPTION
When adding rows to a manifest the module checks if the row has more
columns than are expected by the checklist. If so, the unused columns
are thrown away. This commit adds a check that issues a warning if a
removed column contains data. Added a test to check for the warning

Fixed a data file from a different test, which throws up that warning
while checking something else.