### PR TITLE
Fix AMR regex

### DIFF
--- a/lib/Bio/Metadata/Types.pm
+++ b/lib/Bio/Metadata/Types.pm
@@ -46,7 +46,7 @@ subtype AntimicrobialName,
 
 subtype AMRString,
   as Str,
-  where { m/(([A-Za-z0-9\-\/\(\)\s]+);([SIR]);(lt|le|eq|gt|ge)?(((\d+)?\.)?\d+)(;(\w+))?),?\s*/ },
+  where { m/(([A-Za-z0-9\-\/\(\)\s]+);([SIRU]);(lt|le|eq|gt|ge)?(((\d+)?\.)?\d+)(;(\w+))?),?\s*/ },
   message { 'Not a valid antimicrobial resistance test result' };
 # NOTE this regex isn't quite right. It will still allow broken AMR strings
 # after a comma, e.g. am1;S;10,am2. That second, incomplete term should mean

--- a/lib/Bio/Metadata/Types.pm
+++ b/lib/Bio/Metadata/Types.pm
@@ -46,7 +46,7 @@ subtype AntimicrobialName,
 
 subtype AMRString,
   as Str,
-  where { m/(([A-Za-z0-9\-\/\(\)\s]+);([SIRU]);(lt|le|eq|gt|ge)?(((\d+)?\.)?\d+)(;(\w+))?),?\s*/ },
+  where { m/^((([A-Za-z0-9\-\/\(\)\s]+);([SIRU])(;(?=[\w;])((lt|le|eq|gt|ge)?(((\d+)?\.)?\d+))?(;(\w+))?)?),?\s*)+$/ },
   message { 'Not a valid antimicrobial resistance test result' };
 # NOTE this regex isn't quite right. It will still allow broken AMR strings
 # after a comma, e.g. am1;S;10,am2. That second, incomplete term should mean

--- a/t/00_cachefile.t
+++ b/t/00_cachefile.t
@@ -13,8 +13,10 @@ use File::stat;
 use_ok( 'Test::CacheFile' );
 
 # clear out the cache directory before we start
-remove_tree( $Test::CacheFile::CACHE_DIR, {error => \my $errors} );
-if ( @$errors ) {
+my $errors;
+remove_tree( $Test::CacheFile::CACHE_DIR, {error => \$errors} )
+  if -e $Test::CacheFile::CACHE_DIR;
+if ( $errors ) {
   foreach my $error ( @$errors ) {
     my ( $file, $message ) = %$error;
     die "ERROR: couldn't delete cache directory ($Test::CacheFile::CACHE_DIR): $message"


### PR DESCRIPTION
Update the AMR regex in the type library.

Fix a test that fails on linux but not OSX (or, at least, with different versions of the dependencies maybe). Check that the temp directory used for the tests exists before trying to remove it prior to testing.